### PR TITLE
only show marquee to guests

### DIFF
--- a/resources/views/core/header.blade.php
+++ b/resources/views/core/header.blade.php
@@ -61,6 +61,8 @@
         </div>
     </div>
 </nav>
+
+@if (Auth::guest())
 <header class="marquee">
     <div class="row">
         <div class="col-lg-12" style="text-align: center;">
@@ -73,6 +75,8 @@
         </div>
     </div>
 </header>
+@endif
+
 <div class="container">
     @if (count($announcements) > 0)
         <div class="row">


### PR DESCRIPTION
This hides the marquee for logged in users - which makes it especially easier to use on mobile. 

Previously on Mobile:
![image](https://cloud.githubusercontent.com/assets/882381/10949971/6af9408e-82ea-11e5-9c0a-90a172c6c3a3.png)

After:
![image](https://cloud.githubusercontent.com/assets/882381/10949982/75e901f0-82ea-11e5-8510-400f7ec31747.png)
